### PR TITLE
Enable renovate to make pull-request for all npm patch dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,17 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "npm": {
+    "separateMinorPatch": true,
+    "packageRules": [
+      {
+        "packagePatterns": ["*"],
+        "patch": {
+          "groupName": "all npm patch dependencies",
+          "groupSlug": "all-npm-patch"
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Currently, many npm updates are minor patches.
And it is unnecessary to keep separating every pull-requests.